### PR TITLE
Use isTrue# for GHC >= 7.8

### DIFF
--- a/src/Data/SafeInt.hs
+++ b/src/Data/SafeInt.hs
@@ -13,7 +13,7 @@
 --
 --------------------------------------------------------------------------
 
-{-# LANGUAGE MagicHash, UnboxedTuples, BangPatterns #-}
+{-# LANGUAGE CPP, MagicHash, UnboxedTuples, BangPatterns #-}
 
 module Data.SafeInt (SafeInt(..), fromSafe, toSafe) where
 
@@ -24,6 +24,29 @@ import GHC.Num
 import GHC.Word
 import GHC.Real
 import GHC.Types
+
+-- GHC 7.8 changed the types of the Int# comparison operators in GHC.Prim. For example
+--
+-- > (>#) :: Int# -> Int# -> Bool
+--
+-- became
+--
+-- > (>#) :: Int# -> Int# -> Int#
+--
+-- We are now supposed to use
+--
+-- > isTrue# :: Int# -> Bool
+--
+-- from GHC.Types to recover the Bool [1].
+-- [1] https://ghc.haskell.org/trac/ghc/wiki/PrimBool#Implementationdetails
+--
+-- This CPP macro allows us to write code for both versions.
+--
+#if MIN_VERSION_base(4,7,0)
+#define isTrue isTrue#
+#else
+#define isTrue
+#endif
 
 newtype SafeInt = SI Int
 
@@ -114,17 +137,17 @@ instance Enum SafeInt where
 
 eftInt :: Int# -> Int# -> [SafeInt]
 -- [x1..x2]
-eftInt x0 y | x0 ># y    = []
+eftInt x0 y | isTrue (x0 ># y) = []
             | otherwise = go x0
                where
-                 go x = SI (I# x) : if x ==# y then [] else go (x +# 1#)
+                 go x = SI (I# x) : if isTrue (x ==# y) then [] else go (x +# 1#)
 
 {-# INLINE [0] eftIntFB #-}
 eftIntFB :: (SafeInt -> r -> r) -> r -> Int# -> Int# -> r
-eftIntFB c n x0 y | x0 ># y    = n
+eftIntFB c n x0 y | isTrue (x0 ># y) = n
                   | otherwise = go x0
                  where
-                   go x = SI (I# x) `c` if x ==# y then n else go (x +# 1#)
+                   go x = SI (I# x) `c` if isTrue (x ==# y) then n else go (x +# 1#)
                         -- Watch out for y=maxBound; hence ==, not >
         -- Be very careful not to have more than one "c"
         -- so that when eftInfFB is inlined we can inline
@@ -139,25 +162,25 @@ eftIntFB c n x0 y | x0 ># y    = n
 efdInt :: Int# -> Int# -> [SafeInt]
 -- [x1,x2..maxInt]
 efdInt x1 x2
- | x2 >=# x1 = case maxInt of I# y -> efdtIntUp x1 x2 y
+ | isTrue (x2 >=# x1) = case maxInt of I# y -> efdtIntUp x1 x2 y
  | otherwise = case minInt of I# y -> efdtIntDn x1 x2 y
 
 efdtInt :: Int# -> Int# -> Int# -> [SafeInt]
 -- [x1,x2..y]
 efdtInt x1 x2 y
- | x2 >=# x1 = efdtIntUp x1 x2 y
+ | isTrue (x2 >=# x1) = efdtIntUp x1 x2 y
  | otherwise = efdtIntDn x1 x2 y
 
 {-# INLINE [0] efdtIntFB #-}
 efdtIntFB :: (SafeInt -> r -> r) -> r -> Int# -> Int# -> Int# -> r
 efdtIntFB c n x1 x2 y
- | x2 >=# x1  = efdtIntUpFB c n x1 x2 y
+ | isTrue (x2 >=# x1) = efdtIntUpFB c n x1 x2 y
  | otherwise  = efdtIntDnFB c n x1 x2 y
 
 -- Requires x2 >= x1
 efdtIntUp :: Int# -> Int# -> Int# -> [SafeInt]
 efdtIntUp x1 x2 y    -- Be careful about overflow!
- | y <# x2   = if y <# x1 then [] else [SI (I# x1)]
+ | isTrue (y <# x2) = if isTrue (y <# x1) then [] else [SI (I# x1)]
  | otherwise = -- Common case: x1 <= x2 <= y
                let !delta = x2 -# x1 -- >= 0
                    !y' = y -# delta  -- x1 <= y' <= y; hence y' is representable
@@ -165,14 +188,14 @@ efdtIntUp x1 x2 y    -- Be careful about overflow!
                    -- Invariant: x <= y
                    -- Note that: z <= y' => z + delta won't overflow
                    -- so we are guaranteed not to overflow if/when we recurse
-                   go_up x | x ># y'  = [SI (I# x)]
+                   go_up x | isTrue (x ># y') = [SI (I# x)]
                            | otherwise = SI (I# x) : go_up (x +# delta)
                in SI (I# x1) : go_up x2
 
 -- Requires x2 >= x1
 efdtIntUpFB :: (SafeInt -> r -> r) -> r -> Int# -> Int# -> Int# -> r
 efdtIntUpFB c n x1 x2 y    -- Be careful about overflow!
- | y <# x2   = if y <# x1 then n else SI (I# x1) `c` n
+ | isTrue (y <# x2) = if isTrue (y <# x1) then n else SI (I# x1) `c` n
  | otherwise = -- Common case: x1 <= x2 <= y
                let !delta = x2 -# x1 -- >= 0
                    !y' = y -# delta  -- x1 <= y' <= y; hence y' is representable
@@ -180,14 +203,14 @@ efdtIntUpFB c n x1 x2 y    -- Be careful about overflow!
                    -- Invariant: x <= y
                    -- Note that: z <= y' => z + delta won't overflow
                    -- so we are guaranteed not to overflow if/when we recurse
-                   go_up x | x ># y'   = SI (I# x) `c` n
+                   go_up x | isTrue (x ># y') = SI (I# x) `c` n
                            | otherwise = SI (I# x) `c` go_up (x +# delta)
                in SI (I# x1) `c` go_up x2
 
 -- Requires x2 <= x1
 efdtIntDn :: Int# -> Int# -> Int# -> [SafeInt]
 efdtIntDn x1 x2 y    -- Be careful about underflow!
- | y ># x2   = if y ># x1 then [] else [SI (I# x1)]
+ | isTrue (y ># x2) = if isTrue (y ># x1) then [] else [SI (I# x1)]
  | otherwise = -- Common case: x1 >= x2 >= y
                let !delta = x2 -# x1 -- <= 0
                    !y' = y -# delta  -- y <= y' <= x1; hence y' is representable
@@ -195,7 +218,7 @@ efdtIntDn x1 x2 y    -- Be careful about underflow!
                    -- Invariant: x >= y
                    -- Note that: z >= y' => z + delta won't underflow
                    -- so we are guaranteed not to underflow if/when we recurse
-                   go_dn x | x <# y'  = [SI (I# x)]
+                   go_dn x | isTrue (x <# y') = [SI (I# x)]
                            | otherwise = SI (I# x) : go_dn (x +# delta)
    in SI (I# x1) : go_dn x2
 
@@ -203,7 +226,7 @@ efdtIntDn x1 x2 y    -- Be careful about underflow!
 -- Requires x2 <= x1
 efdtIntDnFB :: (SafeInt -> r -> r) -> r -> Int# -> Int# -> Int# -> r
 efdtIntDnFB c n x1 x2 y    -- Be careful about underflow!
- | y ># x2 = if y ># x1 then n else SI (I# x1) `c` n
+ | isTrue (y ># x2) = if isTrue (y ># x1) then n else SI (I# x1) `c` n
  | otherwise = -- Common case: x1 >= x2 >= y
                let !delta = x2 -# x1 -- <= 0
                    !y' = y -# delta  -- y <= y' <= x1; hence y' is representable
@@ -211,7 +234,7 @@ efdtIntDnFB c n x1 x2 y    -- Be careful about underflow!
                    -- Invariant: x >= y
                    -- Note that: z >= y' => z + delta won't underflow
                    -- so we are guaranteed not to underflow if/when we recurse
-                   go_dn x | x <# y'   = SI (I# x) `c` n
+                   go_dn x | isTrue (x <# y') = SI (I# x) `c` n
                            | otherwise = SI (I# x) `c` go_dn (x +# delta)
                in SI (I# x1) `c` go_dn x2
 


### PR DESCRIPTION
This allows `safeint` to be compiled by GHC 7.8.3 (OS X). The tests passed.

I have not tried this with GHC < 7.8. If it's easy for you, I would appreciate that testing. If not, I can do it.
