### PR TITLE
Update to work with GHC 7.8

### DIFF
--- a/safeint.cabal
+++ b/safeint.cabal
@@ -32,7 +32,7 @@ Test-suite TestSafeInt
                      test-framework-hunit,
                      test-framework-quickcheck2,
                      HUnit,
-                     QuickCheck >= 2.4 && < 3,
+                     QuickCheck >= 2.4 && < 2.8,
                      safeint == 0.5.3
   Default-language:  Haskell2010
   Hs-source-dirs:    tests

--- a/tests/TestSafeInt.hs
+++ b/tests/TestSafeInt.hs
@@ -5,14 +5,12 @@ import Test.Framework as TF
 import Test.Framework.Providers.HUnit
 import Test.Framework.Providers.QuickCheck2
 import Test.HUnit as T
-import Test.QuickCheck
-import Test.QuickCheck.Property
+import Test.QuickCheck hiding ((===))
 import Data.SafeInt
 import Data.Word
 import Data.List
 import Data.Maybe
 import Control.Exception as E
-import GHC.Err
 
 main :: IO ()
 main = defaultMain tests
@@ -67,6 +65,6 @@ anyInt = choose (minBound, maxBound)
 propBinOp :: (forall a. Integral a => a -> a -> a) -> Property
 propBinOp (!) = forAll anyInt $ \ x ->
                 forAll anyInt $ \ y ->
-                morallyDubiousIOProperty $
+                ioProperty $
                 behavesOk (fromIntegral x ! fromIntegral y)
 


### PR DESCRIPTION
Not sure what to do about the following warnings.  Any idea?
```
src/Data/SafeInt.hs:108:1: Warning:
    Rule "eftInt" may never fire because ‘eftInt’ might inline first
    Probable fix: add an INLINE[n] or NOINLINE[n] pragma on ‘eftInt’

src/Data/SafeInt.hs:131:1: Warning:
    Rule "efdtInt" may never fire because ‘efdtInt’ might inline first
    Probable fix: add an INLINE[n] or NOINLINE[n] pragma on ‘efdtInt’

src/Data/SafeInt.hs:301:3: Warning:
    Rule "sum/SafeInt" may never fire because ‘sum’ might inline first
    Probable fix: add an INLINE[n] or NOINLINE[n] pragma on ‘sum’

src/Data/SafeInt.hs:302:3: Warning:
    Rule "product/SafeInt" may never fire
      because ‘product’ might inline first
    Probable fix: add an INLINE[n] or NOINLINE[n] pragma on ‘product’

src/Data/SafeInt.hs:306:3: Warning:
    Rule "sum/SafeInt" may never fire because ‘sum’ might inline first
    Probable fix: add an INLINE[n] or NOINLINE[n] pragma on ‘sum’

src/Data/SafeInt.hs:307:3: Warning:
    Rule "product/SafeInt" may never fire
      because ‘product’ might inline first
    Probable fix: add an INLINE[n] or NOINLINE[n] pragma on ‘product’
```